### PR TITLE
Normalize sitemap domain handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import Work from "@/app/sections/Work";
 import AIStack from "@/app/sections/AIStack";
 import Footer from "@/app/sections/Footer";
 import ScrollRestoration from "@/components/ScrollRestoration";
+import { getSiteUrl } from "@/lib/site-url";
 
 import type { Metadata } from "next";
 
@@ -23,11 +24,12 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
+  const siteUrl = getSiteUrl();
   const portfolioJsonLd = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: "Muhammad Raffey - Portfolio",
-    url: process.env.NEXT_PUBLIC_SITE_URL || "https://www.muhammadraffey.xyz",
+    url: siteUrl,
     description:
       "Portfolio website of Muhammad Raffey, an Agentic AI Engineer and Full-Stack Developer",
     author: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from "next";
 
+import { getSiteUrl } from "@/lib/site-url";
+
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.muhammadraffey.xyz";
+  const baseUrl = getSiteUrl();
 
   return {
     rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,27 +1,28 @@
 import { MetadataRoute } from "next";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  // Use environment variable or fallback to the correct domain
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://www.muhammadraffey.xyz";
+import { getSiteUrl } from "@/lib/site-url";
 
-  // Ensure URLs are properly formatted
+export const revalidate = 86400; // 24 hours
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const lastModified = new Date().toISOString();
   const urls = [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "weekly" as const,
       priority: 1,
     },
     {
       url: `${baseUrl}/certificates`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "monthly" as const,
       priority: 0.8,
     },
     {
       url: `${baseUrl}/contact`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "monthly" as const,
       priority: 0.8,
     },

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,27 @@
+const FALLBACK_URL = "https://muhammadraffey.xyz";
+
+/**
+ * Normalises the public site URL so that generated metadata such as the
+ * sitemap and robots.txt always reference a crawlable, canonical domain.
+ */
+export function getSiteUrl(): string {
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.VERCEL_URL?.trim();
+
+  if (!envUrl) {
+    return FALLBACK_URL;
+  }
+
+  try {
+    const hasProtocol = envUrl.startsWith("http://") || envUrl.startsWith("https://");
+    const url = new URL(hasProtocol ? envUrl : `https://${envUrl}`);
+
+    // Ensure we only return the origin (no trailing slash, query, or hash).
+    return url.origin;
+  } catch (error) {
+    console.warn("Invalid site URL provided. Falling back to default.", error);
+    return FALLBACK_URL;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a shared helper to normalise the public site URL so metadata is generated with a canonical domain
- update the sitemap and robots metadata to use the helper and add a 24-hour revalidation window
- switch the homepage JSON-LD to the canonical site URL helper

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e12964cac8833182d3435443cad9d4