### PR TITLE
Add canonical URL metadata to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,8 @@ import { getSiteUrl } from "@/lib/site-url";
 
 import type { Metadata } from "next";
 
+const canonicalUrl = getSiteUrl();
+
 export const metadata: Metadata = {
   title:
     "Muhammad Raffey | AI Engineer Portfolio - Agentic AI & Full-Stack Development",
@@ -20,6 +22,9 @@ export const metadata: Metadata = {
     title: "Muhammad Raffey | AI Engineer Portfolio",
     description:
       "Agentic AI Engineer portfolio featuring AI-powered applications, multi-agent systems, and modern web development projects.",
+  },
+  alternates: {
+    canonical: canonicalUrl,
   },
 };
 


### PR DESCRIPTION
## Summary
- compute the canonical site URL once at module scope for reuse
- extend the homepage metadata with a canonical alternate link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12db9465083319369f6fb72d7a2f7